### PR TITLE
Shifted functions to other modules

### DIFF
--- a/motive/__init__.py
+++ b/motive/__init__.py
@@ -1,6 +1,6 @@
 __author__ = 'nico'
 
 from native import *
-from camera import *
-from rigidbody import *
+from camera import get_cams, Camera
+from rigidbody import RigidBody
 

--- a/src/camera.pyx
+++ b/src/camera.pyx
@@ -38,9 +38,18 @@ def set_group_shutter_delay(int groupIndex, int microseconds):
 
 #CLASS
 class Camera(object):
+
     def __init__(self, cameraIndex):
         assert cameraIndex < TT_CameraCount(), "There Are Only {0} Cameras".format(TT_CameraCount())
         self.index=cameraIndex
+
+    def __str__(self):
+        return "Camera {0}: {1}".format(self.index, TT_CameraName(self.index))
+
+    @property
+    def name(self):
+        """Camera Name"""
+        return TT_CameraName(self.index)
 
     @property
     def group(self):
@@ -153,10 +162,6 @@ class Camera(object):
 #    print "Set"
 
 #Properties Without Simple Setter (If Not Here Maybe In Camera Class)
-    @property
-    def name(self):
-        """Camera Name"""
-        return TT_CameraName(self.index)
 
     @property
     @check_cam_setting

--- a/src/camera.pyx
+++ b/src/camera.pyx
@@ -51,7 +51,7 @@ class Camera(object):
 
     @group.setter
     def group(self,value):
-        return TT_SetCameraGroup(self.index, value)
+        TT_SetCameraGroup(self.index, value)
 
     @property
     @check_cam_setting

--- a/src/camera.pyx
+++ b/src/camera.pyx
@@ -16,7 +16,7 @@ def get_cams():
     Initiate all cameras as python objects,
     where camera #k is cam[k-1]
     """
-    return [Camera(cameraIndex) for cameraIndex in xrange(TT_CameraCount())]
+    return tuple(Camera(cameraIndex) for cameraIndex in xrange(TT_CameraCount()))
 
 
 class Camera(object):

--- a/src/camera.pyx
+++ b/src/camera.pyx
@@ -44,9 +44,7 @@ class Camera(object):
 
     @property
     def group(self):
-        """
-        Camera's camera group index
-        """
+        """Camera's camera group index"""
         return TT_CamerasGroup(self.index)
 
     @group.setter
@@ -56,13 +54,7 @@ class Camera(object):
     @property
     @check_cam_setting
     def video_type(self):
-        """
-        0:"Segment Mode"
-        1:"Grayscale Mode"
-        2:"Object Mode"
-        3:"Precision Mode"
-        4:"MJPEG Mode"
-        """
+        """0:"Segment Mode"\n 1:"Grayscale Mode"\n 2:"Object Mode"\n 3:"Precision Mode"\n 4:"MJPEG Mode" """
         return TT_CameraVideoType(self.index)
 
     @video_type.setter
@@ -73,9 +65,7 @@ class Camera(object):
     @property
     @check_cam_setting
     def exposure(self):
-        """
-        Camera exposure level.
-        """
+        """Camera exposure level."""
         return TT_CameraExposure(self.index)
 
     @exposure.setter
@@ -85,11 +75,7 @@ class Camera(object):
     @property
     @check_cam_setting
     def threshold(self):
-        """
-        Camera threshold level for determining
-        whether a pixel is bright enough to
-        contain a reflective marker
-        """
+        """Camera threshold level for determining whether a pixel is bright enough to contain a reflective marker."""
         return TT_CameraThreshold(self.index)
 
     @threshold.setter
@@ -122,10 +108,7 @@ class Camera(object):
     @property
     @check_cam_setting
     def frame_rate(self):
-        """
-        frames/sec
-        int
-        """
+        """frames/sec"""
         return TT_CameraFrameRate(self.index)
 
     @frame_rate.setter
@@ -136,9 +119,7 @@ class Camera(object):
     @property
     @check_cam_setting
     def grayscale_decimation(self):
-        """
-        returns int
-        """
+        """returns int"""
         return  TT_CameraGrayscaleDecimation(self.index)
 
     @grayscale_decimation.setter
@@ -149,9 +130,7 @@ class Camera(object):
     @property
     @check_cam_setting
     def imager_gain(self):
-        """
-        returns int
-        """
+        """returns int"""
         return  TT_CameraImagerGainLevels(self.index)
 
     @imager_gain.setter
@@ -161,9 +140,7 @@ class Camera(object):
 
     @property
     def continuous_ir(self):
-        """
-        bool
-        """
+        """bool"""
         assert TT_IsContinuousIRAvailable(self.index), "Camera {0} Does Not Support Continuous IR".format(self.index)
         return TT_ContinuousIR(self.index)
 
@@ -178,9 +155,7 @@ class Camera(object):
 #Properties Without Simple Setter (If Not Here Maybe In Camera Class)
     @property
     def name(self):
-        """
-        Camera Name
-        """
+        """Camera Name"""
         return TT_CameraName(self.index)
 
     @property
@@ -193,11 +168,7 @@ class Camera(object):
         return TT_CameraXLocation(self.index), TT_CameraYLocation(self.index), TT_CameraZLocation(self.index)
 
     def orientation_matrix(self, int matrixIndex):
-        """
-        According to TT_CameraModel()
-        the orientation matrix
-        is a 3x3 matrix.
-        """
+        """According to TT_CameraModel(), the orientation matrix is a 3x3 matrix."""
         return TT_CameraOrientationMatrix(self.index, matrixIndex)
 
     def model(self, float x, float y, float z,             #Camera Position
@@ -238,9 +209,7 @@ class Camera(object):
 
     @property
     def marker_count(self):
-        """
-        Camera's 2D Marker Count
-        """
+        """Camera's 2D Marker Count"""
         return TT_CameraMarkerCount(self.index)
 
     #CAMERA MASKING
@@ -286,9 +255,7 @@ class Camera(object):
         TT_CameraDistort2DPoint(self.index, x, y)
 
     def marker(self, int markerIndex):
-        """
-        CameraMarker fetches the 2D centroid location of the marker as seen by the camera
-        """
+        """CameraMarker fetches the 2D centroid location of the marker as seen by the camera"""
         cdef float x=0
         cdef float y=0
         if TT_CameraMarker(self.index, markerIndex, x, y):
@@ -316,9 +283,7 @@ class Camera(object):
         return cameraX, cameraY
 
     def ray(self, float x, float y):
-        """
-        Takes an undistorted 2D centroid and return a camera ray in the world coordinate system.
-        """
+        """Takes an undistorted 2D centroid and return a camera ray in the world coordinate system."""
         cdef float rayStartX=0
         cdef float rayStartY=0
         cdef float rayStartZ=0
@@ -356,17 +321,13 @@ class Camera(object):
             raise BufferError("Camera Frame Could Not Be Buffered")
 
     def frame_buffer_save_as_bmp(self, str filename):
-        """
-        Save camera's frame buffer as a BMP image file
-        """
+        """Save camera's frame buffer as a BMP image file"""
         if not TT_CameraFrameBufferSaveAsBMP(self.index, filename):
             raise IOError("Camera Frame Buffer Not Successfully Saved To Filename: {0}.".format(filename))
 
 #Functions To Set Camera Property Value, But W\O Possibility To Get Value
     def set_filter_switch(self, bool enableIRFilter):
-        """
-        True: IRFilter, False: VisibleLight
-        """
+        """True: IRFilter, False: VisibleLight"""
         if not TT_SetCameraFilterSwitch(self.index, enableIRFilter):
             raise Exception("Could Not Switch Filter. Possibly Camera Has No IR Filter")
 

--- a/src/camera.pyx
+++ b/src/camera.pyx
@@ -11,14 +11,32 @@ def check_cam_setting(func):
             return check
     return wrapper
 
+#FUNCTIONS
 def get_cams():
-    """
-    Initiate all cameras as python objects,
-    where camera #k is cam[k-1]
-    """
+    """Initiate all cameras as python objects, where camera #k is cam[k-1]"""
     return tuple(Camera(cameraIndex) for cameraIndex in xrange(TT_CameraCount()))
 
+#CAMERA GROUP SUPPORT
+def camera_group_count():
+    """Returns number of camera groups"""
+    return TT_CameraGroupCount()
 
+def create_camera_group():
+    """Add an additional group"""
+    if not TT_CreateCameraGroup():
+        raise Exception("Could Not Create Camera Group")
+
+def remove_camera_group(int groupIndex):
+    """Remove a camera group (must be empty)"""
+    if not TT_RemoveCameraGroup(groupIndex):
+        raise Exception("Could Not Remove. Check If Group Empty")
+
+def set_group_shutter_delay(int groupIndex, int microseconds):
+    """Set camera group's shutter delay"""
+    TT_SetGroupShutterDelay(groupIndex, microseconds)
+
+
+#CLASS
 class Camera(object):
     def __init__(self, cameraIndex):
         assert cameraIndex < TT_CameraCount(), "There Are Only {0} Cameras".format(TT_CameraCount())

--- a/src/camera.pyx
+++ b/src/camera.pyx
@@ -212,6 +212,17 @@ class Camera(object):
         """Camera's 2D Marker Count"""
         return TT_CameraMarkerCount(self.index)
 
+    @property
+    def markers(self):
+        """A tuple of 2D centroid locations of the marker as seen by the camera"""
+        cdef float x = 0, y = 0
+        markers = []
+        for marker_index in xrange(TT_CameraMarkerCount(self.index)):
+            TT_CameraMarker(self.index, markerIndex, x, y)
+            markers.append((x, y))
+        return tuple(markers)
+
+
     #CAMERA MASKING
     def mask(self, buffername, int bufferSize):
         assert isinstance(buffername,str), "Buffername Needs To Be String"
@@ -253,15 +264,6 @@ class Camera(object):
         to a distorted point call CameraDistort2DPoint.
         """
         TT_CameraDistort2DPoint(self.index, x, y)
-
-    def marker(self, int markerIndex):
-        """CameraMarker fetches the 2D centroid location of the marker as seen by the camera"""
-        cdef float x=0
-        cdef float y=0
-        if TT_CameraMarker(self.index, markerIndex, x, y):
-            return x, y
-        else:
-            raise Exception("Could Not Fetch Location. Possibly Marker {0} Is Not Seen By Camera".format(markerIndex))
 
     def pixel_resolution(self):
         cdef int width=0

--- a/src/native.pyx
+++ b/src/native.pyx
@@ -201,36 +201,6 @@ def flush_camera_queues():
     TT_FlushCameraQueues()
 
 
-#CAMERA GROUP SUPPORT
-def camera_group_count():
-    """
-    Returns number of camera groups
-    """
-    return TT_CameraGroupCount()
-
-def create_camera_group():
-    """
-    Add an additional group
-    """
-    if not TT_CreateCameraGroup():
-        raise Exception("Could Not Create Camera Group")
-
-def remove_camera_group(int groupIndex):
-    """
-    Remove a camera group (must be empty)
-    """
-    if not TT_RemoveCameraGroup(groupIndex):
-        raise Exception("Could Not Remove. Check If Group Empty")
-
-def set_group_shutter_delay(int groupIndex, int microseconds):
-    """
-    Set camera group's shutter delay
-    """
-    TT_SetGroupShutterDelay(groupIndex, microseconds)
-
-
-#RIGID BODY CONTROL
-
 #MARKER SIZE SETTINGS
 @check_npresult
 def set_camera_group_reconstruction(int groupIndex, bool enable):

--- a/src/native.pyx
+++ b/src/native.pyx
@@ -231,54 +231,6 @@ def set_group_shutter_delay(int groupIndex, int microseconds):
 
 #RIGID BODY CONTROL
 
-
-rigidBodyCount=0
-
-def rigidBody_count():
-    """
-    returns number of rigid bodies
-    """
-    return rigidBodyCount
-
-
-
-@check_npresult
-def create_rigid_body(str name, markerList):
-     """
-     The marker list is expected to contain a list of marker coordinates in the order:
-     x1,y1,z1,x2,y2,z2,...xN,yN,zN.
-     """
-     id = rigidBody_count()-1
-     cdef float markerListp[1000]
-     markerCount=len(markerList)
-     assert markerCount<=1000, "Due to need of const C array size, markerList max items=1000. \n Please resize const in native.pyx"
-     for i in range(0,len(markerList)):
-         markerListp[3*i]=markerList[i][0]
-         markerListp[3*i+1]=markerList[i][1]
-         markerListp[3*i+2]=markerList[i][2]
-     if (TT_CreateRigidBody(name, id, markerCount, markerListp)==0):
-         global rigidBodyCount
-         rigidBodyCount=rigidBodyCount+1
-     return TT_CreateRigidBody(name, id, markerCount, markerListp)
-
-@check_npresult
-def remove_rigid_body(int rigidIndex):
-    """
-    Remove single rigid body
-    """
-    if (TT_RemoveRigidBody(rigidIndex)==0):
-        global rigidBodyCount
-        rigidBodyCount=rigidBodyCount-1
-    return TT_RemoveRigidBody(rigidIndex)
-
-def clear_rigid_body_list():
-    """
-    Clear all rigid bodies
-    """
-    TT_ClearRigidBodyList()
-    global rigidBodyCount
-    rigidBodyCount=0
-
 #MARKER SIZE SETTINGS
 @check_npresult
 def set_camera_group_reconstruction(int groupIndex, bool enable):

--- a/src/native.pyx
+++ b/src/native.pyx
@@ -156,7 +156,7 @@ def stream_np(bool enabled):
 
 
 #MARKERS
-def frame_markers():
+def get_frame_markers():
     """
     Returns list of all marker positions.
     """

--- a/src/native.pyx
+++ b/src/native.pyx
@@ -160,7 +160,7 @@ def frame_markers():
     """
     Returns list of all marker positions.
     """
-    return [[TT_FrameMarkerX(idx), TT_FrameMarkerY(idx), TT_FrameMarkerZ(idx)] for idx in xrange(TT_FrameMarkerCount())]
+    return tuple((TT_FrameMarkerX(i), TT_FrameMarkerY(i), TT_FrameMarkerZ(i)) for i in xrange(TT_FrameMarkerCount()))
 
 
 # def unident_markers(int rigidBody_count):

--- a/src/rigidbody.pyx
+++ b/src/rigidbody.pyx
@@ -18,7 +18,55 @@ def check_npresult(func):
             raise error(msg)
     return wrapper
 
+#FUNCTIONS
+rigidBodyCount=0
+def rigidBody_count():
+    """
+    returns number of rigid bodies
+    """
+    return rigidBodyCount
 
+
+@check_npresult
+def create_rigid_body(str name, markerList):
+     """
+     The marker list is expected to contain a list of marker coordinates in the order:
+     x1,y1,z1,x2,y2,z2,...xN,yN,zN.
+     """
+     id = rigidBody_count()-1
+     cdef float markerListp[1000]
+     markerCount=len(markerList)
+     assert markerCount<=1000, "Due to need of const C array size, markerList max items=1000. \n Please resize const in native.pyx"
+     for i in range(0,len(markerList)):
+         markerListp[3*i]=markerList[i][0]
+         markerListp[3*i+1]=markerList[i][1]
+         markerListp[3*i+2]=markerList[i][2]
+     if (TT_CreateRigidBody(name, id, markerCount, markerListp)==0):
+         global rigidBodyCount
+         rigidBodyCount=rigidBodyCount+1
+     return TT_CreateRigidBody(name, id, markerCount, markerListp)
+
+
+@check_npresult
+def remove_rigid_body(int rigidIndex):
+    """
+    Remove single rigid body
+    """
+    if (TT_RemoveRigidBody(rigidIndex)==0):
+        global rigidBodyCount
+        rigidBodyCount=rigidBodyCount-1
+    return TT_RemoveRigidBody(rigidIndex)
+
+def clear_rigid_body_list():
+    """
+    Clear all rigid bodies
+    """
+    TT_ClearRigidBodyList()
+    global rigidBodyCount
+    rigidBodyCount=0
+
+
+#CLASS
 class RigidBody(object):
     def __init__(self, rigidIndex):
         """Returns a RigidBody Motive API object."""

--- a/src/rigidbody.pyx
+++ b/src/rigidbody.pyx
@@ -105,10 +105,10 @@ class RigidBody(object):
 
             # Add the marker if one was found (tracked was True). Else, put None in its position in the list!
             # TODO: decide what to do with the not_tracked case.
-            marker = [x, y, z] if tracked else None
-            markers.append([x, y, z])
+            marker = (x, y, z) if tracked else None
+            markers.append(marker)
 
-        return markers
+        return tuple(markers)
 
     @check_npresult
     def translate_pivot(self, float x, float y, float z):


### PR DESCRIPTION
There are 2 main changes here:
   - I moved most of the functions relating to rigid bodies and camera groups to the rigidbody.pyx and camera.pyx modules.  The main benefit of doing this is that it seperates functionality among the three modules a little cleaner. 
   - I made the imports in the __init__.py module more specific for these modules.  This is intended so that the most useful functions are accessible from the base motive package (as well as the tested ones!), and that the more specific ones can be found inside each module itself.  For example, the create_rigid_body() function is still accessible in the motive.rigidbody.create_rigid_body() path.  However, it's obviously a lot harder to get there than the motive.RigidBody(index) approach.  (That said, it would be great to have a get_rigid_bodies() function that works the same as the get_cams() function).
    
Anyway, I hope you like the changes and that they don't break anything (!!), and I look forward to seeing you on Thursday for our Skeleton meeting!

-Nick